### PR TITLE
Use bitfields rather than raw bitwise math for accessing battle stats

### DIFF
--- a/include/Combat/Main/BattleList.h
+++ b/include/Combat/Main/BattleList.h
@@ -1,54 +1,46 @@
 #pragma once
 
-#define BUFF_BITS_START 0x1d
-#define BUFF_BITS_ATTACK 0x1d
-#define BUFF_BITS_DEFENSE 0x1a
-#define BUFF_BITS_AGILITY 0x17
-#define BUFF_BITS_CHARM 0x14
-#define BUFF_BITS_MAGICAL_MIGHT 0x11
-#define BUFF_BITS_MAGICAL_MENDING 0xe
-
-#define STAT_BITS_START 0x16
-#define STAT_BITS_CHARM 0x16
-#define STAT_MASK_CHARM 0x3FF
-#define STAT_BITS_MAGICAL_MIGHT 0xC
-#define STAT_BITS_MAGICAL_MENDING 0x2
-#define STAT_BITS_PER_STAT 0xA
-
 struct PrimaryCombatStats {
-	unsigned short currHP;
-	unsigned short currMP;
-	unsigned short maxHP;
-	unsigned short maxMP;
-	unsigned short attack;
-	unsigned short defense;
-	unsigned short agility;
-	unsigned short unk;
-	int packedStats;
+    unsigned short currHP;
+    unsigned short currMP;
+    unsigned short maxHP;
+    unsigned short maxMP;
+    unsigned short attack;
+    unsigned short defense;
+    unsigned short agility;
+    unsigned short unk;
+    unsigned int charm : 10;
+    unsigned int magicalMight : 10;
+    unsigned int magicalMending : 10;
 };
 
 struct BaseCombatStats {
-	char unk[0x2C];
-	struct PrimaryCombatStats primaryStats;
+    char unk[0x2C];
+    struct PrimaryCombatStats primaryStats;
 };
 
 struct ModifiableCombatStats {
-	struct PrimaryCombatStats primaryStats;// 0xE
-	char unk1[0x44];
-	int buffPack;
+    struct PrimaryCombatStats primaryStats; // 0xE
+    char unk1[0x44];
+    signed int attackBuff : 3;
+    signed int defenseBuff : 3;
+    signed int agilityBuff : 3;
+    signed int charmBuff : 3;
+    signed int magicalMightBuff : 3;
+    signed int magicalMendingBuff : 3;
 };
 
 struct CombatantStruct {
-	unsigned short flags;
-	char unk[0x132];
-	struct BaseCombatStats* baseStats; // TODO: holds more general info than just stats
-	struct ModifiableCombatStats* currentStats; // includes things like buffs being applied
+    unsigned short flags;
+    char unk[0x132];
+    struct BaseCombatStats* baseStats; // TODO: holds more general info than just stats
+    struct ModifiableCombatStats* currentStats; // includes things like buffs being applied
 };
 
 struct BattleStruct {
-	int unk0;
-	int unk4;
-	struct CombatantStruct* combatantList[0xe9]; // TODO: validate this size as well as this struct as a whole
+    int unk0;
+    int unk4;
+    struct CombatantStruct* combatantList[0xe9]; // TODO: validate this size as well as this struct as a whole
 };
 struct BattleStruct* GetBattleStruct();
 struct CombatantStruct* GetCombatantFromList(struct BattleStruct* battleStruct, int id);

--- a/src/Combat/Overlay_0/UpdateCombatantBuffs.c
+++ b/src/Combat/Overlay_0/UpdateCombatantBuffs.c
@@ -21,10 +21,8 @@ void UpdateCombatantAttack(int unused, int combatantId) {
     if (combatantIsPlayer != 0) {
         maxAttack = 999;
     }
-    attackBuff = combatant->currentStats->buffPack;
+    attackBuff = combatant->currentStats->attackBuff;
     attack = combatant->baseStats->primaryStats.attack;
-    attackBuff <<= BUFF_BITS_ATTACK;
-    attackBuff >>= BUFF_BITS_START;
     buffMultiplier = CalculateAttackBuffMultiplier(attackBuff);
     buffedAttack = buffMultiplier * attack;
     if (maxAttack < buffedAttack) {
@@ -53,10 +51,8 @@ void UpdateCombatantDefense(int unused, int combatantId) {
     if (combatantIsPlayer != 0) {
         maxDefense = 999;
     }
-    defenseBuff = combatant->currentStats->buffPack;
+    defenseBuff = combatant->currentStats->defenseBuff;
     defense = combatant->baseStats->primaryStats.defense;
-    defenseBuff <<= BUFF_BITS_DEFENSE;
-    defenseBuff >>= BUFF_BITS_START;
     buffMultiplier = CalculateDefenseBuffMultiplier(defenseBuff);
     buffedDefense = buffMultiplier * defense;
     if (maxDefense < buffedDefense) {
@@ -79,7 +75,7 @@ void UpdateCombatantAgility(int unused, int combatantId) {
         return;
     }
     agility = combatant->baseStats->primaryStats.agility;
-    agilityMultiplier = CalculateAgilityBuffMultiplier((combatant->currentStats->buffPack << BUFF_BITS_AGILITY) >> BUFF_BITS_START);
+    agilityMultiplier = CalculateAgilityBuffMultiplier(combatant->currentStats->agilityBuff);
     agilityBuffed = agilityMultiplier * agility;
     if (maxAgility < agilityBuffed) {
         combatant->currentStats->primaryStats.agility = 999;
@@ -99,14 +95,14 @@ void UpdateCombatantCharm(int unused, int combatantId) {
     if (combatant == NULL) {
         return;
     }
-    charmBuffValue = (combatant->currentStats->buffPack << BUFF_BITS_CHARM) >> BUFF_BITS_START;
-    charm = (unsigned int)(combatant->baseStats->primaryStats.packedStats << STAT_BITS_CHARM) >> STAT_BITS_START;
+    charmBuffValue = combatant->currentStats->charmBuff;
+    charm = combatant->baseStats->primaryStats.charm;
     charmMultiplier = CalculateCharmBuffMultiplier(charmBuffValue);
     charmBuffed = charmMultiplier * charm;
     if (maxCharm < charmBuffed) {
-        combatant->currentStats->primaryStats.packedStats = (combatant->currentStats->primaryStats.packedStats & 0xFFFFFC00) | maxCharm;
+        combatant->currentStats->primaryStats.charm = maxCharm;
     } else {
-        combatant->currentStats->primaryStats.packedStats = (combatant->currentStats->primaryStats.packedStats & 0xFFFFFC00) | (charmBuffed & STAT_MASK_CHARM);
+        combatant->currentStats->primaryStats.charm = charmBuffed;
     }
 }
 
@@ -121,19 +117,19 @@ void UpdateCombatantMagicalMight(int unused, int combatantId) {
     if (combatant == NULL) {
         return;
     }
-    magicalMightBuff = (combatant->currentStats->buffPack << BUFF_BITS_MAGICAL_MIGHT) >> BUFF_BITS_START;
-    magicalMight = (unsigned int)(combatant->baseStats->primaryStats.packedStats << STAT_BITS_MAGICAL_MIGHT) >> STAT_BITS_START;
+    magicalMightBuff = combatant->currentStats->magicalMightBuff;
+    magicalMight = combatant->baseStats->primaryStats.magicalMight;
     buffMultiplier = CalculateMagicalMightBuffMultiplier(magicalMightBuff);
     magicalMightBuffed = buffMultiplier * magicalMight;
     if (maxMagicalMight < magicalMightBuffed) {
-        combatant->currentStats->primaryStats.packedStats = (combatant->currentStats->primaryStats.packedStats & 0xFFF003FF) | (maxMagicalMight << STAT_BITS_PER_STAT);
+        combatant->currentStats->primaryStats.magicalMight = maxMagicalMight;
     } else {
-        combatant->currentStats->primaryStats.packedStats = (combatant->currentStats->primaryStats.packedStats & 0xFFF003FF) | ((unsigned int)(magicalMightBuffed << STAT_BITS_START) >> STAT_BITS_MAGICAL_MIGHT);
+        combatant->currentStats->primaryStats.magicalMight = magicalMightBuffed;
     }
 }
 
 void UpdateCombatantMagicalMending(int unused, int combatantId) {
-        unsigned short magicalMending;
+    unsigned short magicalMending;
     unsigned int magicalMendingBuff;
     unsigned short magicalMendingBuffed;
     const short maxMagicalMending = 999;
@@ -143,14 +139,14 @@ void UpdateCombatantMagicalMending(int unused, int combatantId) {
     if (combatant == NULL) {
         return;
     }
-    magicalMendingBuff = (combatant->currentStats->buffPack << BUFF_BITS_MAGICAL_MENDING) >> BUFF_BITS_START;
-    magicalMending = (unsigned int)(combatant->baseStats->primaryStats.packedStats << STAT_BITS_MAGICAL_MENDING) >> STAT_BITS_START;
+    magicalMendingBuff = combatant->currentStats->magicalMendingBuff;
+    magicalMending = combatant->baseStats->primaryStats.magicalMending;
     buffMultiplier = CalculateMagicalMendingBuffMultiplier(magicalMendingBuff);
     magicalMendingBuffed = buffMultiplier * magicalMending;
     if (maxMagicalMending < magicalMendingBuffed) {
-        combatant->currentStats->primaryStats.packedStats = (combatant->currentStats->primaryStats.packedStats & 0xc00ffffF) | (maxMagicalMending << (STAT_BITS_PER_STAT*2));
+        combatant->currentStats->primaryStats.magicalMending = maxMagicalMending;
     } else {
-        combatant->currentStats->primaryStats.packedStats = (combatant->currentStats->primaryStats.packedStats & 0xc00ffffF) | ((unsigned int)(magicalMendingBuffed << STAT_BITS_START) >> STAT_BITS_MAGICAL_MENDING);
+        combatant->currentStats->primaryStats.magicalMending = magicalMendingBuffed;
     }
 }
 


### PR DESCRIPTION
This results in cleaner code. This may be necessary for matching as well (this should match with both -O2 and -O4, while existing code only matched with -O4, see #1)