### PR TITLE
CalculateCritRate cleanup

### DIFF
--- a/src/Combat/Main/CritRateCalculation.cpp
+++ b/src/Combat/Main/CritRateCalculation.cpp
@@ -1,19 +1,19 @@
 #include <globaldefs.h>
 ARM float CalculateCritRate(int deftness, float accessoryBonus, float bookBonus, float skillBonus, unsigned char hitCount) {
-    float baseChanceFloat;
-    float critChance;
-    float hitCountFloat;
     float minimumChance = 2.0f;
-    int baseChance = (deftness - 150) * 0x10000 >> 0x10;
+
+    // there is some bit shifting in the assembly here, 16 left and 16 right and those preserve the most significant bit. A conversion to short seems extremely likely
+    short baseChance = (deftness - 150);
     if (baseChance < 0) {
         baseChance = 0;
     }
-    baseChanceFloat = baseChance;
-    baseChanceFloat = 0.01f * baseChanceFloat;
-    hitCountFloat = hitCount;
-    hitCountFloat = 1.0f / hitCountFloat; // results in multiplying by 0.5 for 2 hits, 0.333~ for 3, etc. kinda makes crits on multihit moves bad though
+    float baseChanceFloat = 0.01f * (float)baseChance;    
+    
+    float hitCountFloat = 1.0f / float(hitCount); // results in multiplying by 0.5 for 2 hits, 0.333~ for 3, etc. kinda makes crits on multihit moves bad though
+    
     baseChanceFloat = minimumChance + baseChanceFloat;
-    critChance = accessoryBonus + baseChanceFloat;
+
+    float critChance = accessoryBonus + baseChanceFloat;
     critChance = bookBonus + critChance;
     critChance = skillBonus * critChance;
     return hitCountFloat * critChance;


### PR DESCRIPTION
I was trying to get familiar with the project and DS decompilation. So I looked at the already decompiled code and this line `(deftness - 150) * 0x10000 >> 0x10` caught my attention. Some "random" multiplication and bit shifts. Experimenting what they do to the deftness number it appeared as if they did absolutely nothing to it. Looking at the assembly, that line compiled to:

```asm
sub        deftness,deftness,#0x96
mov        deftness,deftness, lsl #0x10
movs       deftness,deftness, asr #0x10
```

So there wasn't a multiplication, just a bit shift, also by 0x10 which happens to be 16 in decimal. Furthermore, the `asr` instruction preserves the most significant bit, meaning it effectively converts the 32 bit int into a 16 bit short. Recompiling with that produced the same assembly, so it's probably correct? I see no real reason to do that here, so my best guess is that the variable in the character stats is also a short, but it got packed into a 32 bit register, and we have some compiler shenanigans going on? Either that or they accidentally used the wrong type, but because it makes no difference no one ever noticed.

While I was at it, I also rewrote it slightly so it looks more like something a human would actually write. I didn't manage to clean the `minimumChance` variable or its addition to the `baseChanceFloat` at all, without breaking the byte match so it stayed as is.