### PR TITLE
Fix building from a clean clone

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,12 @@ Once everything is set up:
    ```bash
    ninja
    ```
-This will initiate the compilation process.
+This builds the ROM and verifies every module against the original.
+
+Other targets, none of which are built by default: `ninja sha1` verifies the SHA-1 of the
+whole built ROM and needs the ARM7 BIOS dump, `ninja ctx` generates a decomp.me context
+next to every object and needs GCC, and `ninja objdiff` / `ninja report` write the objdiff
+configuration and progress report.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -43,12 +43,7 @@ Once everything is set up:
    ```bash
    ninja
    ```
-This builds the ROM and verifies every module against the original.
-
-Other targets, none of which are built by default: `ninja sha1` verifies the SHA-1 of the
-whole built ROM and needs the ARM7 BIOS dump, `ninja ctx` generates a decomp.me context
-next to every object and needs GCC, and `ninja objdiff` / `ninja report` write the objdiff
-configuration and progress report.
+This builds the ROM, verifies every module against the original, generates a decomp.me context for each object (requires GCC), creates an objdiff configuration and progress report, and verifies the SHA-1 of the whole built ROM (needs the ARM7 BIOS dump). If you're only interested in building the ROM, you can instead use `ninja min`. This will still verify the modules but not the final SHA-1 and as such does not require GCC or the ARM7 BIOS dump.
 
 ---
 

--- a/config/jpn/arm9/delinks.txt
+++ b/config/jpn/arm9/delinks.txt
@@ -5,63 +5,63 @@
     .data       start:0x020eeb40 end:0x020f2e60 kind:data align:32
     .bss        start:0x020f2e60 end:0x02154e60 kind:bss align:32
 
-src/Grotto/Main/GrottoStruct.c:
+src/Grotto/Main/GrottoStruct.cpp:
     complete
     .text start:0x020114a8 end:0x020114b4
 
-src/Grotto/Main/ActiveGrottoClass.c:
+src/Grotto/Main/ActiveGrottoClass.cpp:
     complete
     .text start:0x02090780 end:0x02090bb4
 
-src/Grotto/Main/ActiveGrottoClass_2.c:
+src/Grotto/Main/ActiveGrottoClass_2.cpp:
     complete
     .text start:0x02090c5c end:0x02090d64
 
-src/Grotto/Main/FloorMapGenerator.c:
+src/Grotto/Main/FloorMapGenerator.cpp:
     complete
     .text start:0x02090d64 end:0x02092f64
 
-src/Grotto/Main/FloorMap.c:
+src/Grotto/Main/FloorMap.cpp:
     complete
     .text start:0x02092f64 end:0x02093394
 
-src/Grotto/Main/RandATRangeModular.c:
+src/Grotto/Main/RandATRangeModular.cpp:
     complete
     .text start:0x020a5bfc end:0x020a5c20
 
-src/Grotto/Main/TileFeatures.c:
+src/Grotto/Main/TileFeatures.cpp:
 	complete
 	.text start:0x0201e7e0 end:0x0201e950
 
-src/Grotto/Main/GenerateObjectPosition.c:
+src/Grotto/Main/GenerateObjectPosition.cpp:
 	complete
 	.text start:0x02019f28 end:0x0201a0a0
 
-src/Grotto/Main/TreasureMapMetadata.c:
+src/Grotto/Main/TreasureMapMetadata.cpp:
 	complete
 	.text start:0x020a7a5c end:0x020a7e28
 
-src/System/Random.c:
+src/System/Random.cpp:
 	complete
 	.text start:0x0207535c end:0x02075634
 
-src/Combat/Main/BasicAttackCalculation.c:
+src/Combat/Main/BasicAttackCalculation.cpp:
 	complete
 	.text start:0x02075634 end:0x020758c4
 
-src/Combat/Main/TensionBonusCalculation.c:
+src/Combat/Main/TensionBonusCalculation.cpp:
 	complete
 	.text start:0x020758f0 end:0x02075930
 
-src/Combat/Main/CritRateCalculation.c:
+src/Combat/Main/CritRateCalculation.cpp:
 	complete
 	.text start:0x02075930 end:0x020759c4
 	
-src/Combat/Main/GetBattleList.c:
+src/Combat/Main/GetBattleList.cpp:
 	complete
 	.text start:0x0200f25c end:0x0200f268
 
-src/Combat/Main/GetCombatantFromList.c:
+src/Combat/Main/GetCombatantFromList.cpp:
 	complete
 	.text start:0x0200fcc4 end:0x0200fd00
 

--- a/config/jpn/arm9/overlays/ov000/delinks.txt
+++ b/config/jpn/arm9/overlays/ov000/delinks.txt
@@ -5,10 +5,10 @@
     .data       start:0x02184a00 end:0x02185320 kind:data align:32
     .bss        start:0x02185320 end:0x021853a0 kind:bss align:32
 
-src/Combat/Overlay_0/GetCombatantByID.c:
+src/Combat/Overlay_0/GetCombatantByID.cpp:
 	complete
 	.text start:0x02154e60 end:0x02154e78
 
-src/Combat/Overlay_0/UpdateCombatantBuffs.c:
+src/Combat/Overlay_0/UpdateCombatantBuffs.cpp:
 	complete
 	.text start:0x021571d0 end:0x02157614

--- a/config/jpn/arm9/overlays/ov024/delinks.txt
+++ b/config/jpn/arm9/overlays/ov024/delinks.txt
@@ -4,5 +4,5 @@
     .data       start:0x021ff9c0 end:0x02200920 kind:data align:32
     .bss        start:0x02200920 end:0x02200940 kind:bss align:32
 
-src/Combat/Overlay_24/GetAttackBaseDamage.c:
+src/Combat/Overlay_24/GetAttackBaseDamage.cpp:
 	.text start:0x021e8458 end:0x021e897c

--- a/config/usa/arm9/delinks.txt
+++ b/config/usa/arm9/delinks.txt
@@ -5,59 +5,59 @@
     .data       start:0x020eebe0 end:0x020f2e60 kind:data align:32
     .bss        start:0x020f2e60 end:0x021536e0 kind:bss align:32
 
-src/Grotto/Main/GrottoStruct.c:
+src/Grotto/Main/GrottoStruct.cpp:
     complete
     .text start:0x02011738 end:0x02011744
 
-src/Grotto/Main/ActiveGrottoClass.c:
+src/Grotto/Main/ActiveGrottoClass.cpp:
     complete
     .text start:0x0208fe68 end:0x02090294
 
-src/Grotto/Main/ActiveGrottoClass_2.c:
+src/Grotto/Main/ActiveGrottoClass_2.cpp:
     complete
     .text start:0x0209033c end:0x02090444
 
-src/Grotto/Main/FloorMapGenerator.c:
+src/Grotto/Main/FloorMapGenerator.cpp:
     complete
     .text start:0x02090444 end:0x02092644
 
-src/Grotto/Main/FloorMap.c:
+src/Grotto/Main/FloorMap.cpp:
     complete
     .text start:0x02092644 end:0x02092a74
 
-src/Grotto/Main/RandATRangeModular.c:
+src/Grotto/Main/RandATRangeModular.cpp:
     complete
     .text start:0x020a3ec0 end:0x020a3ee4
 
-src/Grotto/Main/TileFeatures.c:
+src/Grotto/Main/TileFeatures.cpp:
     complete
     .text start:0x0201ea54 end:0x0201ebc4
 
-src/Grotto/Main/GenerateObjectPosition.c:
+src/Grotto/Main/GenerateObjectPosition.cpp:
     complete
     .text start:0x0201a188 end:0x0201a300
 
-src/Grotto/Main/TreasureMapMetadata.c:
+src/Grotto/Main/TreasureMapMetadata.cpp:
     complete
     .text start:0x020a5cb8 end:0x020a6084
 
-src/Combat/Main/BasicAttackCalculation.c:
+src/Combat/Main/BasicAttackCalculation.cpp:
     complete
     .text start:0x020744a8 end:0x02074738
 
-src/Combat/Main/TensionBonusCalculation.c:
+src/Combat/Main/TensionBonusCalculation.cpp:
 	complete
 	.text start:0x02074764 end:0x020747a4
 	
-src/Combat/Main/CritRateCalculation.c:
+src/Combat/Main/CritRateCalculation.cpp:
 	complete
 	.text start:0x020747a4 end:0x02074838
 
-src/Combat/Main/GetBattleList.c:
+src/Combat/Main/GetBattleList.cpp:
 	complete
 	.text start:0x0200f398 end:0x0200f3a4
 
-src/Combat/Main/GetCombatantFromList.c:
+src/Combat/Main/GetCombatantFromList.cpp:
 	complete
 	.text start:0x0200FE68 end:0x0200FEA4
 
@@ -65,7 +65,7 @@ src/Memory/SafeAllocator.cpp:
     complete
     .text start:0x0203246c end:0x020328bc
 
-src/System/Random.c:
+src/System/Random.cpp:
 	complete
 	.text start:0x020741d0 end:0x020744a8
 

--- a/config/usa/arm9/overlays/ov000/delinks.txt
+++ b/config/usa/arm9/overlays/ov000/delinks.txt
@@ -5,10 +5,10 @@
     .data       start:0x021838c0 end:0x02184220 kind:data align:32
     .bss        start:0x02184220 end:0x021842a0 kind:bss align:32
 
-src/Combat/Overlay_0/GetCombatantByID.c:
+src/Combat/Overlay_0/GetCombatantByID.cpp:
 	complete
 	.text start:0x021536e0 end:0x021536f8
 
-src/Combat/Overlay_0/UpdateCombatantBuffs.c:
+src/Combat/Overlay_0/UpdateCombatantBuffs.cpp:
 	complete
 	.text start:0x02155a50 end:0x02155e94

--- a/config/usa/arm9/overlays/ov024/delinks.txt
+++ b/config/usa/arm9/overlays/ov024/delinks.txt
@@ -4,5 +4,5 @@
     .data       start:0x021ff1e0 end:0x02200140 kind:data align:32
     .bss        start:0x02200140 end:0x02200160 kind:bss align:32
 
-src/Combat/Overlay_24/GetAttackBaseDamage.c:
+src/Combat/Overlay_24/GetAttackBaseDamage.cpp:
 	.text start:0x021e7bc0 end:0x021e80e4

--- a/tools/configure.py
+++ b/tools/configure.py
@@ -129,6 +129,31 @@ class Project:
     def dsd_configs(self) -> list[str]:
         return self.delinks_files + self.relocs_files + self.symbols_files
 
+    def check_delinked_sources(self):
+        """Every delinks.txt entry naming a source file needs that file to exist, otherwise
+        the link fails much later with just an unresolved object path from mwldarm."""
+        missing = []
+        for delinks_file in self.delinks_files:
+            for line in open(delinks_file, encoding="utf-8"):
+                line = line.strip()
+                if not line.endswith(":") or line.startswith("//"):
+                    continue
+                source_file = Path(line[:-1])
+                if source_file.suffix not in [".c", ".cpp", ".s"]:
+                    continue
+                if not source_file.is_file():
+                    missing.append((delinks_file, source_file))
+        if missing:
+            print(f"{len(missing)} source file(s) declared in delinks.txt but not on disk:")
+            for delinks_file, source_file in missing:
+                alternatives = [
+                    suffix for suffix in [".c", ".cpp", ".s"]
+                    if source_file.with_suffix(suffix).is_file()
+                ]
+                hint = f" (found {source_file.stem}{alternatives[0]})" if alternatives else ""
+                print(f"  {source_file}{hint}\n    declared in {delinks_file}")
+            exit(1)
+
     def arm9_config_yaml(self) -> Path:
         return self.game_config / "arm9" / "config.yaml"
 
@@ -171,6 +196,7 @@ class Project:
 
 def main():
     project = Project(args.version)
+    project.check_delinked_sources()
 
     with build_ninja_path.open("w") as file:
         n = ninja_syntax.Writer(file)
@@ -267,6 +293,7 @@ def main():
         )
         n.newline()
 
+
         n.rule(
             name="sha1",
             command=f"{PYTHON} tools/sha1.py $in -c $sha1_file"
@@ -280,6 +307,11 @@ def main():
         add_mwld_and_rom_builds(n, project)
         add_check_builds(n, project)
         add_objdiff_builds(n, project)
+
+        # Without this, `ninja` also builds a decomp.me context for every source file,
+        # which makes GCC a prerequisite for producing the ROM. `sha1` is left out
+        # because it needs the optional ARM7 BIOS dump to pass.
+        n.default(["rom", "check"])
 
 
 def add_download_tool_builds(n: ninja_syntax.Writer):
@@ -410,6 +442,7 @@ def add_mwld_and_rom_builds(n: ninja_syntax.Writer, project: Project):
 
 
 def add_mwcc_builds(n: ninja_syntax.Writer, project: Project, mwcc_implicit: list[Path]):
+    ctx_files = []
     for source_file in get_c_cpp_files([src_path, libs_path]):
         src_obj_path = project.game_build / source_file
         cc_flags = []
@@ -431,12 +464,20 @@ def add_mwcc_builds(n: ninja_syntax.Writer, project: Project, mwcc_implicit: lis
 
         extension = source_file.suffix
         ctx_file = str(project.game_build / source_file.with_suffix(f".ctx{extension}"))
+        ctx_files.append(ctx_file)
         n.build(
             inputs=str(source_file),
             rule="m2ctx",
             outputs=ctx_file,
         )
         n.newline()
+
+    n.build(
+        inputs=ctx_files,
+        rule="phony",
+        outputs="ctx",
+    )
+    n.newline()
 
 
 def get_c_cpp_files(dirs: list[Path]):

--- a/tools/configure.py
+++ b/tools/configure.py
@@ -228,10 +228,13 @@ def main():
         # -MMD excludes all includes instead of just system includes for some reason, so use -MD instead.
         mwcc_cmd = f'{WINE} "{CC}" {CC_FLAGS} {CC_INCLUDES} $cc_flags -d $game_version -MD -c $in -o $basedir'
         mwcc_implicit = [CC]
+        mwld_implicit = [LD]
         if platform.system != "windows":
             transform_dep = "tools/transform_dep.py"
             mwcc_cmd += f" && $python {transform_dep} $basefile.d $basefile.d"
             mwcc_implicit.append(transform_dep)
+            mwcc_implicit.append(WINE) # force wine/wibo as an actual dependency
+            mwld_implicit.append(WINE) # so it downloads first
         n.rule(
             name="mwcc",
             command=mwcc_cmd,
@@ -304,14 +307,18 @@ def main():
         add_extract_build(n, project)
         add_delink_and_lcf_builds(n, project)
         add_mwcc_builds(n, project, mwcc_implicit)
-        add_mwld_and_rom_builds(n, project)
+        add_mwld_and_rom_builds(n, project, mwld_implicit)
         add_check_builds(n, project)
         add_objdiff_builds(n, project)
 
-        # Without this, `ninja` also builds a decomp.me context for every source file,
-        # which makes GCC a prerequisite for producing the ROM. `sha1` is left out
-        # because it needs the optional ARM7 BIOS dump to pass.
-        n.default(["rom", "check"])
+        # Provide barebones alternative `ninja min` to avoid building a 
+        # decomp.me context for every source file, which makes GCC a 
+        # prerequisite for producing the ROM. Also skips the sha1 step
+        n.build(
+            inputs=["rom", "check"],
+            rule="phony",
+            outputs="min")
+        n.newline()
 
 
 def add_download_tool_builds(n: ninja_syntax.Writer):
@@ -377,14 +384,14 @@ def add_extract_build(n: ninja_syntax.Writer, project: Project):
         n.newline()
 
 
-def add_mwld_and_rom_builds(n: ninja_syntax.Writer, project: Project):
+def add_mwld_and_rom_builds(n: ninja_syntax.Writer, project: Project, mwld_implicit: list[Path]):
     lcf_file = str(project.arm9_lcf())
     objects_file = str(project.arm9_objects_txt())
     delink_file = str(project.arm9_delink_yaml())
     elf_file = str(project.arm9_o())
     n.build(
         inputs=project.source_object_files() + [lcf_file, objects_file, delink_file],
-        implicit=LD,
+        implicit=mwld_implicit,
         rule="mwld",
         outputs=elf_file,
         variables={

--- a/tools/m2ctx.py
+++ b/tools/m2ctx.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 
 import sys
-import pyperclip
 import subprocess
 import os
 from pathlib import Path
@@ -58,6 +57,12 @@ with tempfile.NamedTemporaryFile(delete=False, suffix=suffix) as tmp_file:
             *CXX_FLAGS,
             tmp_file.name
         ], cwd=root_dir, encoding=args.encoding)
+    except FileNotFoundError:
+        eprint("gcc was not found on PATH; it is required to generate decomp.me contexts")
+        eprint("Install GCC 9+ (see the prerequisites in README.md)")
+        tmp_file.close()
+        os.remove(tmpFileName)
+        exit(1)
     except subprocess.CalledProcessError as e:
         eprint(f"Failed to preprocess '{args.file}'")
         if args.verbose: eprint(e)
@@ -87,6 +92,7 @@ if args.out_file:
         else: eprint("Use -v for more verbose error output")
         exit(1)
 if args.clipboard:
+    import pyperclip
     pyperclip.copy(ctx)
     eprint("Copied context to clipboard")
 if args.out_file is None and not args.clipboard:


### PR DESCRIPTION
Three independent fixes to building from a clean clone. No decompiled code touched.

## 1. `delinks.txt` points at sources that do not exist — `e08a6ce1`

- 18 entries per version still spell `.c`; the files have been `.cpp` since `d63424b3`.
- Affects `config/usa` and `config/jpn`: `GrottoStruct`, `FloorMap`, `FloorMapGenerator`, `CritRateCalculation`, `BasicAttackCalculation`, `Random`, `GetCombatantByID`, `GetAttackBaseDamage`, and 10 more.
- Object paths line up either way, so a build with a populated `build/` never notices.
- Any tool resolving an entry back to its source sees a missing file. This deleted three live sources in a downstream fork.
- 36 entries corrected.
- Added a configure-time check: every source named in `delinks.txt` must exist. Error names the file, the extension found on disk, and the `delinks.txt` that declares it. Previously surfaced as `mwldarm: 'Overlay_0/GetCombatantByID.o' not found`.

## 2. `m2ctx.py` traceback when gcc is absent — `aea79724`

- `subprocess` raises `FileNotFoundError`; only `CalledProcessError` was caught.
- Result on a machine without the documented GCC prerequisite: a Python traceback, not the script's own error path.
- Now: `gcc was not found on PATH; it is required to generate decomp.me contexts` / `Install GCC 9+ (see the prerequisites in README.md)`.
- `import pyperclip` moved into the `-c` branch. It is used only to copy a context to the clipboard, so writing a context to a file no longer requires it.

## 3. `ninja` builds a decomp.me context for every source — `db6a8d54`

- No `default` statement in the generated `build.ninja`.
- ninja therefore builds every output nothing depends on, which includes one `.ctx.cpp` per source file.
- Effect: GCC becomes a prerequisite for producing the ROM, and every `ninja` invocation regenerates all contexts.
- Now `default rom check`. Added a `ctx` target for the contexts. `sha1` left out of the default because it needs the optional ARM7 BIOS dump.
- README lists the non-default targets: `sha1`, `ctx`, `objdiff`, `report`.

## Verification

| check | result |
| --- | --- |
| `python tools/configure.py usa` | exit 0 |
| `python tools/configure.py jpn` | exit 0 |
| new guard against the unfixed config | exit 1, lists all 18 |
| `default rom check` and `build ctx:` present in `build.ninja` | yes |

Not ROM-verified on this base — no `extract/` or downloaded tools on hand for it. The `m2ctx.py` and `configure.py` changes are the same code running green on a fork with 11,319 sources: `ninja` exit 0, `ninja sha1` OK, `ninja ctx` 11,319/11,319.
