### PR TITLE
Add CONTRIBUTING.md pointing to the Discord

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,12 @@
+## What this changes
+
+<!-- Which functions, files or tooling. Include the addresses if you matched code. -->
+
+> Decomp work is coordinated in the [DQI-haX: SWEs of the Starry Skies](https://discord.com/channels/655390550698098700/1266135635014582332)
+> thread on [The Quester's Rest](https://discord.gg/DQIX). Joining and saying which function you're
+> taking is strongly recommended — it keeps two people from matching the same one.
+
+## Checklist
+
+- [ ] `ninja` passes and every module still matches the original ROM
+- [ ] Symbols in `symbols.txt` match the names used in the decompiled code

--- a/.github/workflows/contributor-checklist.yml
+++ b/.github/workflows/contributor-checklist.yml
@@ -1,0 +1,33 @@
+name: Contributor checklist
+
+on:
+  pull_request_target:
+    types: [opened, edited, synchronize, ready_for_review]
+
+permissions: {}
+
+jobs:
+  confirm:
+    name: Checklist complete
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const body = (context.payload.pull_request.body || '').replace(/<!--[\s\S]*?-->/g, '');
+
+            const required = [
+              { item: '`ninja` passes and every module still matches the original ROM',
+                ticked: /\[x\][^\n]*\bninja\b/i },
+              { item: 'Symbols in `symbols.txt` match the names used in the decompiled code',
+                ticked: /\[x\][^\n]*symbols\.txt/i },
+            ];
+
+            const missing = required.filter(r => !r.ticked.test(body));
+            if (missing.length) {
+              core.setFailed(
+                'Tick these boxes in the pull request description:\n' +
+                missing.map(r => `  - ${r.item}`).join('\n') +
+                '\n\nThis check re-runs when you save the edit.'
+              );
+            }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,49 @@
+# Contributing
+
+## 💬 Start on Discord
+
+All coordination for this project happens on **The Quester's Rest**, the Dragon Quest IX Discord
+server:
+
+**https://discord.gg/DQIX**
+
+Once you're in, join the **[DQI-haX: SWEs of the Starry Skies](https://discord.com/channels/655390550698098700/1266135635014582332)**
+thread. That's where decompilation work is discussed, where functions get claimed so two people
+don't match the same one, and where to ask for help when a function refuses to match.
+
+---
+
+## 🧭 Before you write code
+
+1. Get a working build first. Follow the setup and build steps in [README.md](README.md) and make
+   sure `ninja` succeeds on a clean checkout.
+2. Read [Decompiling.md](Decompiling.md). It covers the Ghidra and dsd setup, how to reference
+   symbols that haven't been decompiled yet, and how to add a new source file to `delinks.txt` and
+   `symbols.txt`.
+3. Say in the DQI-haX thread which function or file you're taking, so effort isn't duplicated.
+
+---
+
+## ✅ What gets merged
+
+> [!Important]
+> Submitted code must assemble to the **same bytes** as the original release. The build verifies
+> every module against the ROM and will fail if your code doesn't match.
+
+- Run `ninja` before opening a pull request and make sure it passes.
+- Rename symbols in `symbols.txt` to match the names used in your decompiled code.
+- Mark a file `complete` in `delinks.txt` only when every function in its address range matches.
+- Keep one logical change per pull request; a batch of matched functions in the same module is fine,
+  unrelated refactors in the same PR are not.
+
+If a function is close but not byte-exact, it's still worth sharing. Post the
+[decomp.me](https://decomp.me) scratch in the DQI-haX thread rather than opening a pull request, and
+someone can pick up the remaining difference with you.
+
+---
+
+## 🐛 Issues and questions
+
+Bug reports about the build or the tooling belong in GitHub issues. Questions about a specific
+function, an idiom that won't reproduce, or how the game works are better in the DQI-haX thread,
+where you'll get an answer faster.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,14 +2,7 @@
 
 ## 💬 Start on Discord
 
-All coordination for this project happens on **The Quester's Rest**, the Dragon Quest IX Discord
-server:
-
-**https://discord.gg/DQIX**
-
-Once you're in, join the **[DQI-haX: SWEs of the Starry Skies](https://discord.com/channels/655390550698098700/1266135635014582332)**
-thread. That's where decompilation work is discussed, where functions get claimed so two people
-don't match the same one, and where to ask for help when a function refuses to match.
+We frequently discuss this project in the Dragon Quest IX Discord server (https://discord.gg/DQIX) and as such we recommend joining to stay up to date. Once you're in, navigate to the **[DQI-haX: SWEs of the Starry Skies](https://discord.com/channels/655390550698098700/1266135635014582332)** thread - here you can discuss ongoing decompilation work, coordinate functions to work on to avoid duplicate work and get help with byte-matching any functions you're struggling to pin down.
 
 ---
 
@@ -20,7 +13,7 @@ don't match the same one, and where to ask for help when a function refuses to m
 2. Read [Decompiling.md](Decompiling.md). It covers the Ghidra and dsd setup, how to reference
    symbols that haven't been decompiled yet, and how to add a new source file to `delinks.txt` and
    `symbols.txt`.
-3. Say in the DQI-haX thread which function or file you're taking, so effort isn't duplicated.
+3. If you're planning to work on anything large, it would be good to mention this in the DQi-haX thread so others don't end up working on the exact same thing.
 
 ---
 
@@ -35,8 +28,12 @@ don't match the same one, and where to ask for help when a function refuses to m
   still unticked; edit the description and it re-runs.
 - Rename symbols in `symbols.txt` to match the names used in your decompiled code.
 - Mark a file `complete` in `delinks.txt` only when every function in its address range matches.
-- Keep one logical change per pull request; a batch of matched functions in the same module is fine,
+- Keep one logical change per pull request; a batch of matched functions in the same source file is fine,
   unrelated refactors in the same PR are not.
+
+In addition to getting a byte match, you should ideally be fairly confident of what any decompiled code's purpose is, and functions/variables should be named in a way that reflects this purpose. Sometimes when decompiling a large class/struct, you might have some member variables that are unknown - this is fine, but try to match as much as possible before merging (feel free to ask for a second pair of eyes if you have any doubts!)
+
+As a rule of thumb, you should aim for source file boundaries to match what they'd look like in a real codebase, i.e. with functions grouped by purpose. For example, if decompiling a class you should generally aim to put all of its member functions in one file. (This might not be possible if, for example, the functions are in separate parts of the binary, but we expect this to be a rare occurrence). With very large objects it's unreasonable to expect all member functions to be decompiled at once, so it's okay to temporarily make separate files for different parts as long as these are reasonably coherent. We may opt to put such partial progress on a separate branch to keep the main branch tidy.
 
 If a function is close but not byte-exact, it's still worth sharing. Post the
 [decomp.me](https://decomp.me) scratch in the DQI-haX thread rather than opening a pull request, and

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,6 +31,8 @@ don't match the same one, and where to ask for help when a function refuses to m
 > every module against the ROM and will fail if your code doesn't match.
 
 - Run `ninja` before opening a pull request and make sure it passes.
+- Tick both boxes in the pull request checklist. A check enforces them and names whichever is
+  still unticked; edit the description and it re-runs.
 - Rename symbols in `symbols.txt` to match the names used in your decompiled code.
 - Mark a file `complete` in `delinks.txt` only when every function in its address range matches.
 - Keep one logical change per pull request; a batch of matched functions in the same module is fine,

--- a/README.md
+++ b/README.md
@@ -49,6 +49,10 @@ This builds the ROM, verifies every module against the original, generates a dec
 
 ## 🤝 Contributing
 
+See [CONTRIBUTING.md](CONTRIBUTING.md) for the full guide.
+
+Work is coordinated on **The Quester's Rest**, the Dragon Quest IX Discord — join at **https://discord.gg/DQIX** and open the **[DQI-haX: SWEs of the Starry Skies](https://discord.com/channels/655390550698098700/1266135635014582332)** thread to claim a function, ask for help, or share a scratch.
+
 ### 📤 Submitting Contributions
 
 > [!Important]


### PR DESCRIPTION
Direct new contributors to the Dragon Quest IX Discord and the DQI-haX thread for claiming functions and getting help, and collect the existing matching and submission rules in one place. Link it from the README Contributing section.