### PR TITLE
Move the Discord note out of the pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,10 +2,6 @@
 
 <!-- Which functions, files or tooling. Include the addresses if you matched code. -->
 
-> Decomp work is coordinated in the [DQI-haX: SWEs of the Starry Skies](https://discord.com/channels/655390550698098700/1266135635014582332)
-> thread on [The Quester's Rest](https://discord.gg/DQIX). Joining and saying which function you're
-> taking is strongly recommended — it keeps two people from matching the same one.
-
 ## Checklist
 
 - [ ] `ninja` passes and every module still matches the original ROM

--- a/.github/workflows/first-interaction.yml
+++ b/.github/workflows/first-interaction.yml
@@ -1,0 +1,36 @@
+name: First interaction
+
+on:
+  pull_request_target:
+    types: [opened]
+  issues:
+    types: [opened]
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  greet:
+    name: Greet a first-time contributor
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/first-interaction@v3
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          pr_message: |
+            Thanks for the pull request, and welcome to the project!
+
+            Decomp work is coordinated in the [DQI-haX: SWEs of the Starry Skies](https://discord.com/channels/655390550698098700/1266135635014582332)
+            thread on [The Quester's Rest](https://discord.gg/DQIX). Joining and saying which function
+            you're taking keeps two people from matching the same one, and it's the fastest place to get
+            help with a function that's close but won't go byte-exact.
+
+            [CONTRIBUTING.md](${{ github.server_url }}/${{ github.repository }}/blob/HEAD/CONTRIBUTING.md) covers what gets merged.
+          issue_message: |
+            Thanks for opening your first issue here!
+
+            Build and tooling bugs belong in GitHub issues, so this is the right place for those.
+            Questions about a specific function, an idiom that won't reproduce, or how the game works
+            get answered faster in the [DQI-haX: SWEs of the Starry Skies](https://discord.com/channels/655390550698098700/1266135635014582332)
+            thread on [The Quester's Rest](https://discord.gg/DQIX).


### PR DESCRIPTION
## What this changes

Moves the Discord coordination note out of the pull request template and into a first-interaction greeting.

The note asked contributors to say which function they were taking so two people don't match the same one. In the template it arrived too late to do that — by the time you're filling in a pull request description you've already picked a function and matched it. It also rendered as real markdown rather than an HTML comment, so unless the author deleted it by hand it survived into the body of every merged pull request.

`.github/workflows/first-interaction.yml` greets a contributor once, on their first issue or pull request, with the same links. `pull_request_target` rather than `pull_request` so the token can still comment on pull requests from forks; there is no checkout step, so the elevated token never runs contributor code.

The template goes back to being a plain form. `CONTRIBUTING.md` already covers coordination for anyone who reads it before starting, and GitHub links to it on the pull request page.

## Checklist

- [x] `ninja` passes and every module still matches the original ROM — no source, `delinks.txt`, `symbols.txt` or build files change here, so the build is untouched
- [x] Symbols in `symbols.txt` match the names used in the decompiled code — no symbols or decompiled code change
