### PR TITLE
Add CI to verify pull requests build and match the original ROM

### DIFF
--- a/.github/workflows/match.yml
+++ b/.github/workflows/match.yml
@@ -1,0 +1,53 @@
+name: Match
+
+on:
+  merge_group:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        version: [usa]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - run: sudo apt-get update && sudo apt-get install -y ninja-build
+
+      - run: python -m pip install -r tools/requirements.txt
+
+      - uses: actions/cache@v4
+        with:
+          path: |
+            tools/mwccarm
+            dsd
+            objdiff-cli
+            wibo
+          key: toolchain-${{ runner.os }}-${{ hashFiles('tools/download_tool.py', 'tools/configure.py') }}
+
+      - name: Fetch baserom and BIOS
+        env:
+          GH_TOKEN: ${{ secrets.BASEROM_TOKEN }}
+          BASEROM_REPO: ${{ secrets.BASEROM_REPO }}
+          BASEROM_TAG: ${{ secrets.BASEROM_TAG }}
+        run: |
+          gh release download "$BASEROM_TAG" -R "$BASEROM_REPO" -p 'baserom_dqix_${{ matrix.version }}.nds' -D extract/
+          gh release download "$BASEROM_TAG" -R "$BASEROM_REPO" -p 'arm7_bios.bin' -D .
+
+      - run: sha1sum -c ci/baseroms_${{ matrix.version }}.sha1
+
+      - run: python tools/configure.py ${{ matrix.version }}
+
+      - run: ninja

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -1,0 +1,27 @@
+name: PR checks
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pr-checks-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  configure:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        version: [usa, jpn]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - run: python -m pip install -r tools/requirements.txt
+      - run: python tools/configure.py ${{ matrix.version }}

--- a/ci/baseroms_usa.sha1
+++ b/ci/baseroms_usa.sha1
@@ -1,0 +1,2 @@
+c7c3014c237900c8281289b8bc76a781969b6278  extract/baserom_dqix_usa.nds
+24f67bdea115a2c847c8813a262502ee1607b7df  arm7_bios.bin


### PR DESCRIPTION
## What this changes

Tooling only, no source changes.

The contributor checklist is an honour system — nothing verifies that a pull request still builds, let alone that every module matches. These two workflows check it.

**`pr-checks.yml`** — runs `configure.py` for both `usa` and `jpn` on every pull request. Holds no secrets, so it works for fork contributions.

Cheaper than it looks. `check_delinked_sources()` catches a source file added to `delinks.txt` but never committed, a path whose case only works on Windows, and config drift in whichever region the author wasn't building. Today those surface much later as an unresolved object path out of `mwldarm`.

**`match.yml`** — the real gate. Full `ninja`: every module verified against the original, plus the final ROM SHA-1.

It needs a baserom, so it runs on `merge_group`, not `pull_request`. Fork pull requests never receive secrets. A merge queue build runs on a branch in this repository and does get them — and it builds `main` plus the pull request rather than the pull request alone, so two changes that each match separately but conflict together get caught before `main` goes red. A pull request only enters the queue when a maintainer clicks Merge when ready.

Everything about where the baserom comes from is configured through secrets. Its hashes are verified before the build starts, so a truncated download fails as a download error rather than a confusing module mismatch.

### Before this gates anything

1. `BASEROM_REPO`, `BASEROM_TAG`, `BASEROM_TOKEN` secrets
2. Merge queue enabled on `main`
3. Branch protection on `main` requiring `build (usa)`

Until step 3, both workflows run and report but block nothing.

### Notes

- Require only `build (usa)`. A merge queue waits for required checks to be reported on the queue branch by `merge_group` runs; `pr-checks.yml` triggers on `pull_request` only, so requiring its jobs would hang every queue entry until it times out. `build (usa)` covers them anyway — `match.yml` runs `configure.py` before `ninja`.
- Matrix is USA-only for now. Add `jpn` to the matrix and a `ci/baseroms_jpn.sha1` alongside it to cover both.
- `match.yml` can't be dry-run before merge — `workflow_dispatch` only offers workflows that exist on the default branch. Create the secrets before merging so the first run on `main` is meaningful.
- Verified locally against `main`: full `ninja`, all 34 overlays plus ARM9/ITCM/DTCM OK, final ROM SHA-1 matching `dqix_usa.sha1`.

## Checklist

- [x] `ninja` passes and every module still matches the original ROM
- [x] Symbols in `symbols.txt` match the names used in the decompiled code
