### PR TITLE
Greet a contributor only on their first pull request

### DIFF
--- a/.github/workflows/first-interaction.yml
+++ b/.github/workflows/first-interaction.yml
@@ -15,16 +15,49 @@ jobs:
     name: Greet a first-time contributor
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/first-interaction@v3
+      - uses: actions/github-script@v7
         with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          pr_message: |
-            Thanks for the pull request, and welcome to the project!
+          script: |
+            const isPullRequest = context.payload.pull_request !== undefined;
+            const number = context.issue.number;
+            const creator = context.payload.sender.login;
 
-            Decomp work is coordinated in the [DQI-haX: SWEs of the Starry Skies](https://discord.com/channels/655390550698098700/1266135635014582332) thread on [The Quester's Rest](https://discord.gg/DQIX). Joining and saying which function you're taking keeps two people from matching the same one, and it's the fastest place to get help with a function that's close but won't go byte-exact.
+            const previous = await github.paginate(github.rest.issues.listForRepo, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              creator,
+              state: 'all',
+              per_page: 100,
+            });
 
-            [CONTRIBUTING.md](${{ github.server_url }}/${{ github.repository }}/blob/HEAD/CONTRIBUTING.md) covers what gets merged.
-          issue_message: |
-            Thanks for opening your first issue here!
+            const priorOfSameKind = previous.filter(
+              (entry) => (entry.pull_request !== undefined) === isPullRequest && entry.number < number
+            );
 
-            Build and tooling bugs belong in GitHub issues, so this is the right place for those. Questions about a specific function, an idiom that won't reproduce, or how the game works get answered faster in the [DQI-haX: SWEs of the Starry Skies](https://discord.com/channels/655390550698098700/1266135635014582332) thread on [The Quester's Rest](https://discord.gg/DQIX).
+            if (priorOfSameKind.length > 0) {
+              core.info(`Skipping: ${creator} has ${priorOfSameKind.length} earlier ${isPullRequest ? 'pull requests' : 'issues'}`);
+              return;
+            }
+
+            const contributing = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/blob/HEAD/CONTRIBUTING.md`;
+
+            const prMessage = [
+              'Thanks for the pull request, and welcome to the project!',
+              '',
+              "Decomp work is coordinated in the [DQI-haX: SWEs of the Starry Skies](https://discord.com/channels/655390550698098700/1266135635014582332) thread on [The Quester's Rest](https://discord.gg/DQIX). Joining and saying which function you're taking keeps two people from matching the same one, and it's the fastest place to get help with a function that's close but won't go byte-exact.",
+              '',
+              `[CONTRIBUTING.md](${contributing}) covers what gets merged.`,
+            ].join('\n');
+
+            const issueMessage = [
+              'Thanks for opening your first issue here!',
+              '',
+              "Build and tooling bugs belong in GitHub issues, so this is the right place for those. Questions about a specific function, an idiom that won't reproduce, or how the game works get answered faster in the [DQI-haX: SWEs of the Starry Skies](https://discord.com/channels/655390550698098700/1266135635014582332) thread on [The Quester's Rest](https://discord.gg/DQIX).",
+            ].join('\n');
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: number,
+              body: isPullRequest ? prMessage : issueMessage,
+            });

--- a/.github/workflows/first-interaction.yml
+++ b/.github/workflows/first-interaction.yml
@@ -21,16 +21,10 @@ jobs:
           pr_message: |
             Thanks for the pull request, and welcome to the project!
 
-            Decomp work is coordinated in the [DQI-haX: SWEs of the Starry Skies](https://discord.com/channels/655390550698098700/1266135635014582332)
-            thread on [The Quester's Rest](https://discord.gg/DQIX). Joining and saying which function
-            you're taking keeps two people from matching the same one, and it's the fastest place to get
-            help with a function that's close but won't go byte-exact.
+            Decomp work is coordinated in the [DQI-haX: SWEs of the Starry Skies](https://discord.com/channels/655390550698098700/1266135635014582332) thread on [The Quester's Rest](https://discord.gg/DQIX). Joining and saying which function you're taking keeps two people from matching the same one, and it's the fastest place to get help with a function that's close but won't go byte-exact.
 
             [CONTRIBUTING.md](${{ github.server_url }}/${{ github.repository }}/blob/HEAD/CONTRIBUTING.md) covers what gets merged.
           issue_message: |
             Thanks for opening your first issue here!
 
-            Build and tooling bugs belong in GitHub issues, so this is the right place for those.
-            Questions about a specific function, an idiom that won't reproduce, or how the game works
-            get answered faster in the [DQI-haX: SWEs of the Starry Skies](https://discord.com/channels/655390550698098700/1266135635014582332)
-            thread on [The Quester's Rest](https://discord.gg/DQIX).
+            Build and tooling bugs belong in GitHub issues, so this is the right place for those. Questions about a specific function, an idiom that won't reproduce, or how the game works get answered faster in the [DQI-haX: SWEs of the Starry Skies](https://discord.com/channels/655390550698098700/1266135635014582332) thread on [The Quester's Rest](https://discord.gg/DQIX).


### PR DESCRIPTION
## What this changes

Fixes the greeting firing on every pull request instead of only a contributor's first, and unwraps the message text.

`actions/first-interaction` skips only when the event is neither the author's first issue nor their first pull request, so it posts whenever either is true. Nobody on this repo opens issues, so that half of the condition is permanently true for everyone and the greeting went out on every pull request. It has already fired on #26 and #27, both from an author with five earlier pull requests.

The step is now `actions/github-script` doing the check directly: count the author's earlier entries of the same kind as the event that fired, and comment only when there are none. Checked against the repo's real history — an author with four earlier pull requests is skipped, and #23, which genuinely was its author's first, is greeted.

The two messages also lose their hard line breaks. GitHub wraps comment text to the reader's width anyway, so the breaks did nothing for the rendered comment and only made the block awkward to edit.

## Checklist

- [x] `ninja` passes and every module still matches the original ROM — no source, `delinks.txt`, `symbols.txt` or build files change here, so the build is untouched
- [x] Symbols in `symbols.txt` match the names used in the decompiled code — no symbols or decompiled code change
