### PR TITLE
Require a check whose name is the same whether the build runs or skips

### DIFF
--- a/.github/workflows/match.yml
+++ b/.github/workflows/match.yml
@@ -55,3 +55,14 @@ jobs:
       - run: python tools/configure.py ${{ matrix.version }}
 
       - run: ninja
+
+  match:
+    needs: build
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          case "${{ needs.build.result }}" in
+            success|skipped) ;;
+            *) echo "build: ${{ needs.build.result }}"; exit 1 ;;
+          esac


### PR DESCRIPTION
## What this changes

```
required context:  build (usa)
reported:          build            SKIPPED
state:             BLOCKED
```

Required checks are matched by exact context string. A matrix job reports under two different names depending on whether it ran:

| State | Reported name |
|---|---|
| Skipped on a pull request | `build` — the matrix never expands |
| Run in the merge queue | `build (usa)` |

Requiring either string leaves the other state with nothing reported. `build (usa)` never arrives on the pull request, so it sits blocked. `build` would never arrive in the queue, so the queue would hang instead. GitHub has no notion that the two names are the same job.

The `match` job reports under one name in every state. It passes when the build succeeded or was skipped and fails otherwise, so requiring `match` still gates on the real result in the queue while letting a skipped pull request through. The `build` job keeps its matrix — adding `jpn` later changes nothing about the ruleset.

Costs one extra job of a few seconds per run.

### After merging

Move the required status check from `build (usa)` to `match`. Nothing gates until that's done.

Then open PRs need a push or a close/reopen to pick up the new workflow — they were opened against an earlier `main`.

## Checklist

- [x] `ninja` passes and every module still matches the original ROM
- [x] Symbols in `symbols.txt` match the names used in the decompiled code
