### PR TITLE
Publish match progress as a report and README badges

### DIFF
--- a/.github/workflows/match.yml
+++ b/.github/workflows/match.yml
@@ -1,6 +1,8 @@
 name: Match
 
 on:
+  push:
+    branches: [main]
   pull_request:
   merge_group:
   workflow_dispatch:
@@ -55,6 +57,61 @@ jobs:
       - run: python tools/configure.py ${{ matrix.version }}
 
       - run: ninja
+
+      - run: ninja report
+
+      - name: Progress summary
+        run: |
+          {
+            echo '### Progress (${{ matrix.version }})'
+            echo '```'
+            python tools/report_badges.py build/${{ matrix.version }}/report.json
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Generate badge data
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        run: python tools/report_badges.py build/${{ matrix.version }}/report.json -o badges/${{ matrix.version }}
+
+      - uses: actions/upload-artifact@v4
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        with:
+          name: badges-${{ matrix.version }}
+          path: badges/
+
+  badges:
+    needs: build
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: badges-*
+          merge-multiple: true
+          path: badges
+
+      - name: Publish to badges branch
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          git init -q -b badges publish
+          cd publish
+          git remote add origin "https://x-access-token:$GITHUB_TOKEN@github.com/${{ github.repository }}.git"
+          if git fetch -q --depth=1 origin badges 2>/dev/null; then
+            git reset -q --hard FETCH_HEAD
+          fi
+          cp -r ../badges/. .
+          git add -A
+          if git diff --cached --quiet; then
+            echo "badges unchanged"
+            exit 0
+          fi
+          git -c user.name='github-actions[bot]' \
+              -c user.email='41898282+github-actions[bot]@users.noreply.github.com' \
+              commit -q -m "Update progress badges for ${{ github.sha }}"
+          git push -q origin badges
 
   match:
     needs: build

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Dragon Quest IX: Sentinels of the Starry Skies Decompilation Project
 
+[![Functions](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2FDQIX%2Fdqix-decomp%2Fbadges%2Fusa%2Ffunctions.json)](https://github.com/DQIX/dqix-decomp/actions/workflows/match.yml)
+[![Bytes](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2FDQIX%2Fdqix-decomp%2Fbadges%2Fusa%2Fbytes.json)](https://github.com/DQIX/dqix-decomp/actions/workflows/match.yml)
+
 ## 📖 About
 This project aims to create a **1:1 disassembly and decompilation** of *Dragon Quest IX: Sentinels of the Starry Skies* for the Nintendo DS.  
 The primary focus is on the USA and Japanese versions of the game, with the goal of making it fully recompilable.

--- a/tools/report_badges.py
+++ b/tools/report_badges.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+
+import argparse
+import json
+from pathlib import Path
+
+COLOR_THRESHOLDS = [(20, "red"), (40, "orange"), (60, "yellow"), (80, "yellowgreen"), (100, "green")]
+
+
+def color_for(percent: float) -> str:
+    for threshold, color in COLOR_THRESHOLDS:
+        if percent < threshold:
+            return color
+    return "brightgreen"
+
+
+def badge(label: str, percent: float) -> dict:
+    return {
+        "schemaVersion": 1,
+        "label": label,
+        "message": f"{percent:.2f}%",
+        "color": color_for(percent),
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Turn an objdiff report into shields.io endpoint badges")
+    parser.add_argument("report", type=Path, help="path to report.json produced by 'ninja report'")
+    parser.add_argument("-o", "--out-dir", type=Path, help="write functions.json and bytes.json here")
+    args = parser.parse_args()
+
+    measures = json.loads(args.report.read_text())["measures"]
+    badges = {
+        "functions": badge("functions", measures["matched_functions_percent"]),
+        "bytes": badge("bytes", measures["matched_code_percent"]),
+    }
+
+    if args.out_dir is not None:
+        args.out_dir.mkdir(parents=True, exist_ok=True)
+        for name, data in badges.items():
+            (args.out_dir / f"{name}.json").write_text(json.dumps(data) + "\n")
+
+    print(
+        f"functions  {badges['functions']['message']:>8}"
+        f"  ({measures['matched_functions']}/{measures['total_functions']})"
+    )
+    print(
+        f"bytes      {badges['bytes']['message']:>8}"
+        f"  ({int(measures['matched_code'])}/{int(measures['total_code'])})"
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What this changes

CI and the README only — no source, no symbols.

`Match` runs `ninja report` after the build, so every gated build also produces objdiff's `report.json`, and prints the matched-function and matched-byte percentages into the job summary. That gives a progress number on pull requests from this repository and in the queue, without anyone having to build locally.

On pushes to `main` those percentages are turned into shields.io endpoint payloads by `tools/report_badges.py` and committed to an orphan `badges` branch. The README reads them as two badges, so the front page tracks `main` on its own.

`push: branches: [main]` is added *alongside* `pull_request` and `merge_group`; neither is touched. The `match` required check still reports on pull requests and in the queue exactly as it does today, and the new `badges` job is the only thing gated on the push event — nothing `needs:` it. The cost is one extra `Match` run per merge, around 30s at steady state.

The badges render as "endpoint not found" until this merges and the first `main` run creates the branch.

Numbers from `ninja report` on this branch: functions 6.97% (1031/14790), bytes 4.74% (140356/2959478).

## Checklist

- [x] `ninja` passes and every module still matches the original ROM
- [x] Symbols in `symbols.txt` match the names used in the decompiled code
